### PR TITLE
CMake updated with export_compile_commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(TDSS VERSION 1.0.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "-02")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(tdss main.cpp)
 


### PR DESCRIPTION
Running Clang-tidy reported missing compile commands so I edited CMake to export them during compilation.